### PR TITLE
Fix validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,14 +123,15 @@ var ColorInputComponent = function (_React$Component) {
       var _props = this.props,
           label = _props.label,
           source = _props.source,
-          touched = _props.touched,
-          error = _props.error,
+          meta = _props.meta,
           className = _props.className,
           options = _props.options,
           picker = _props.picker,
           input = _props.input,
           resource = _props.resource,
           isRequired = _props.isRequired;
+      var touched = meta.touched,
+          error = meta.error;
 
 
       var Picker = ReactColor[picker + 'Picker'];
@@ -177,6 +178,10 @@ ColorInputComponent.propTypes = {
   options: _propTypes2.default.object,
   source: _propTypes2.default.string,
   input: _propTypes2.default.object,
+  meta: _propTypes2.default.shape({
+    touched: _propTypes2.default.bool,
+    error: _propTypes2.default.string
+  }),
   className: _propTypes2.default.string,
   picker: function picker(props, propName, componentName) {
     return !ReactColor[props[propName] + 'Picker'] && new Error('Invalid prop `' + propName + '` supplied to `' + componentName + '`.');

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,7 @@ class ColorInputComponent extends React.Component {
     const {
       label,
       source,
-      touched,
-      error,
+      meta,
       className,
       options,
       picker,
@@ -63,6 +62,11 @@ class ColorInputComponent extends React.Component {
       resource,
       isRequired,
     } = this.props;
+
+    const {
+      touched,
+      error,
+    } = meta;
 
     const Picker = ReactColor[`${picker}Picker`];
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,10 @@ ColorInputComponent.propTypes = {
   options: PropTypes.object,
   source: PropTypes.string,
   input: PropTypes.object,
+  meta: PropTypes.shape({
+    touched: PropTypes.bool,
+    error: PropTypes.string,
+  }),
   className: PropTypes.string,
   picker: (props, propName, componentName) =>
     !ReactColor[`${props[propName]}Picker`] &&


### PR DESCRIPTION
Hi,

adding validation didn't work because the `touched` and `error` values were being taken from `this.props` and not `this.props.meta` as is required. 

Seems like there is a similar issue in the original package; https://github.com/dreinke/aor-color-input/pull/7